### PR TITLE
add in support for half precision floats (float16)

### DIFF
--- a/bitstruct.py
+++ b/bitstruct.py
@@ -51,12 +51,14 @@ def _pack_boolean(size, arg):
 def _pack_float(size, arg):
     value = float(arg)
 
-    if size == 32:
+    if size == 16:
+        value = struct.pack('>e', value)
+    elif size == 32:
         value = struct.pack('>f', value)
     elif size == 64:
         value = struct.pack('>d', value)
     else:
-        raise ValueError('expected float size of 32 of 64 bits (got {})'.format(
+        raise ValueError('expected float size of 16, 32, or 64 bits (got {})'.format(
             size))
 
     return bin(int(b'01' + binascii.hexlify(value), 16))[3:]
@@ -92,12 +94,14 @@ def _unpack_boolean(bits):
 def _unpack_float(size, bits):
     packed = _unpack_bytearray(size, bits)
 
-    if size == 32:
+    if size == 16:
+        value = struct.unpack('>e', packed)[0]
+    elif size == 32:
         value = struct.unpack('>f', packed)[0]
     elif size == 64:
         value = struct.unpack('>d', packed)[0]
     else:
-        raise ValueError('expected float size of 32 of 64 bits (got {})'.format(
+        raise ValueError('expected float size of 16, 32, or 64 bits (got {})'.format(
             size))
 
     return value
@@ -310,7 +314,7 @@ def pack(fmt, *args):
 
     - ``u`` -- unsigned integer
     - ``s`` -- signed integer
-    - ``f`` -- floating point number of 32 or 64 bits
+    - ``f`` -- floating point number of 16, 32, or 64 bits
     - ``b`` -- boolean
     - ``t`` -- text (ascii or utf-8)
     - ``r`` -- raw, bytes

--- a/tests/test_bitstruct.py
+++ b/tests/test_bitstruct.py
@@ -173,7 +173,7 @@ class BitStructTest(unittest.TestCase):
         except ValueError as e:
             self.assertEqual(
                 str(e),
-                'expected float size of 32 of 64 bits (got 33)')
+                'expected float size of 16, 32, or 64 bits (got 33)')
 
         # Too many bits to unpack.
         try:
@@ -214,6 +214,12 @@ class BitStructTest(unittest.TestCase):
         packed = pack('f64', 1.0)
         unpacked = unpack('f64', packed)
         self.assertEqual(unpacked, (1.0, ))
+
+        packed = pack('f16', 1.0)
+        unpacked = unpack('f16', packed)
+        self.assertEqual(unpacked, (1.0, ))
+
+
 
     def test_calcsize(self):
         """Calculate size.
@@ -475,13 +481,13 @@ class BitStructTest(unittest.TestCase):
             pack('f31', 1.0)
 
         self.assertEqual(str(cm.exception),
-                         'expected float size of 32 of 64 bits (got 31)')
+                         'expected float size of 16, 32, or 64 bits (got 31)')
 
         with self.assertRaises(ValueError) as cm:
             unpack('f33', 8 * b'\x00')
 
         self.assertEqual(str(cm.exception),
-                         'expected float size of 32 of 64 bits (got 33)')
+                         'expected float size of 16, 32, or 64 bits (got 33)')
 
     def test_bad_format_type(self):
         """Test of bad format type.

--- a/tests/test_bitstruct.py
+++ b/tests/test_bitstruct.py
@@ -215,11 +215,10 @@ class BitStructTest(unittest.TestCase):
         unpacked = unpack('f64', packed)
         self.assertEqual(unpacked, (1.0, ))
 
-        packed = pack('f16', 1.0)
-        unpacked = unpack('f16', packed)
-        self.assertEqual(unpacked, (1.0, ))
-
-
+        if sys.version_info[0] >= 3 and sys.version_info[1] >= 5:
+            packed = pack('f16', 1.0)
+            unpacked = unpack('f16', packed)
+            self.assertEqual(unpacked, (1.0, ))
 
     def test_calcsize(self):
         """Calculate size.

--- a/tests/test_bitstruct.py
+++ b/tests/test_bitstruct.py
@@ -215,7 +215,7 @@ class BitStructTest(unittest.TestCase):
         unpacked = unpack('f64', packed)
         self.assertEqual(unpacked, (1.0, ))
 
-        if sys.version_info[0] >= 3 and sys.version_info[1] >= 5:
+        if sys.version_info >= (3, 6):
             packed = pack('f16', 1.0)
             unpacked = unpack('f16', packed)
             self.assertEqual(unpacked, (1.0, ))


### PR DESCRIPTION
Now that struct supports half precision floats, so should bitstruct. Thanks for putting this together!