### PR TITLE
 python implementation: limit the size of integer-like objects to 8192 bits

### DIFF
--- a/bitstruct/__init__.py
+++ b/bitstruct/__init__.py
@@ -23,6 +23,10 @@ class _Info(object):
 class _SignedInteger(_Info):
 
     def __init__(self, size, name):
+        max_size = 8192
+        if size > max_size:
+            raise Error(f"size too large at 's{size}': maximum is {max_size}'")
+
         super(_SignedInteger, self).__init__(size, name)
         self.minimum = -2 ** (size - 1)
         self.maximum = -self.minimum - 1
@@ -57,6 +61,10 @@ class _SignedInteger(_Info):
 class _UnsignedInteger(_Info):
 
     def __init__(self, size, name):
+        max_size = 8192
+        if size > max_size:
+            raise Error(f"size too large at 'u{size}': maximum is {max_size}'")
+
         super(_UnsignedInteger, self).__init__(size, name)
         self.maximum = 2 ** size - 1
 

--- a/tests/test_bitstruct.py
+++ b/tests/test_bitstruct.py
@@ -114,6 +114,30 @@ class BitStructTest(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "'float' object has no attribute 'encode'")
 
+        # Too long integer-like values.
+        with self.assertRaises(Error) as cm:
+            pack('b8200', True)
+        with self.assertRaises(Error) as cm:
+            pack('s8200', 0)
+        with self.assertRaises(Error) as cm:
+            pack('u8200', 0)
+        with self.assertRaises(Error) as cm:
+            pack('u99999999999999', 0)
+
+        # Long byte-like objects
+        packed = pack('r10000', b'\xff'*(10000//8))
+        self.assertEqual(packed, b'\xff'*(10000//8))
+
+        packed = pack('t10000', 'a'*(10000//8))
+        self.assertEqual(packed, b'a'*(10000//8))
+
+        packed = pack('p10000')
+        self.assertEqual(packed, b'\x00'*(10000//8))
+
+        packed = pack('P10000')
+        self.assertEqual(packed, b'\xff'*(10000//8))
+
+
     def test_unpack(self):
         """Unpack values.
 
@@ -220,6 +244,30 @@ class BitStructTest(unittest.TestCase):
                           byteswap('414',
                                    b'\x01\x00\x00\x00\x01\xe7\xa2\x91\x00'))
         self.assertEqual(unpacked, (1, 1, 0x12345, 0x67))
+
+        # Too long integer-like values.
+        with self.assertRaises(Error) as cm:
+            unpack('b8200', b'\xff'*(8200//8))
+        with self.assertRaises(Error) as cm:
+            unpack('s8200', b'\xff'*(8200//8))
+        with self.assertRaises(Error) as cm:
+            unpack('u8200', b'\xff'*(8200//8))
+        with self.assertRaises(Error) as cm:
+            unpack('u99999999999999', f'\xff')
+
+        # Long byte-like objects
+        unpacked = unpack('r10000', b'\xff'*(10000//8))
+        self.assertEqual(unpacked, (b'\xff'*(10000//8), ))
+
+        unpacked = unpack('t10000', b'a'*(10000//8))
+        self.assertEqual(unpacked, ('a'*(10000//8), ))
+
+        unpacked = unpack('p10000', b'\x00'*(10000//8))
+        self.assertEqual(unpacked, ())
+
+        unpacked = unpack('P10000', b'a'*(10000//8))
+        self.assertEqual(unpacked, ())
+
 
     def test_pack_unpack(self):
         """Pack and unpack values.


### PR DESCRIPTION
if this is not done, we get hangs and out of memory errors for formats like "u89999888888888888888899" (which occurs in test_c.py). This is due to the statements for determining the maximum and minimum values (i.e. `2**size - 1` for unsigned integers.) 

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)