### PR TITLE
Fix PyPy build

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: [
+          '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8', 'pypy-3.9'
+        ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -19,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
-        python -m pip install .
+        python -m pip install -vvvv .
     - name: Test
       run: |
         python -m pytest -v --assert=plain ./tests

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
-        python -m pip install -vvvv .
+        python -m pip install .
     - name: Test
       run: |
         python -m pytest -v --assert=plain ./tests

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ if platform.python_implementation() == "CPython":
             ],
         )
     ]
+else:
+    ext_modules = []
 
-    setuptools.setup(
-        ext_modules=ext_modules,
-    )
+setuptools.setup(
+    ext_modules=ext_modules,
+)


### PR DESCRIPTION
setuptools.setup() must be called, even if no C extensions are compiled. This was my mistake and caused some failed tests in cantools.