### PR TITLE
Add pure Python wheel to release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,14 @@ jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      PURE_PYTHON: ${{ matrix.pure_python }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+          - pure_python: "true"
       fail-fast: false
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python
+import os
 import platform
 
 import setuptools
 
-if platform.python_implementation() == "CPython":
+
+def _getenv_bool(key: str) -> bool:
+    return os.getenv(key, "false").lower() in ("true", "1")
+
+
+if platform.python_implementation() == "CPython" and not _getenv_bool("PURE_PYTHON"):
     ext_modules = [
         setuptools.Extension(
             "bitstruct.c",


### PR DESCRIPTION
This adds a pure Python wheel (eg. `bitstruct-8.19.0-py3-none-any.whl`) to the output builds for upload to PyPI: https://pypi.org/project/bitstruct/#files.

One useful consequence of this is letting us use packages relying on bitstruct in the browser via Pyodide, which can [easily install](https://pyodide.org/en/stable/usage/loading-packages.html) pure Python wheels.