### PR TITLE
Fix pyproject license deprecation warnings

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8', 'pypy-3.9'
+          '3.9', '3.10', '3.11', '3.12', '3.13',
+          'pypy-3.9', 'pypy-3.10', 'pypy-3.11'
         ]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ and C bit field structs represented as Python \
 byte strings."""
 readme = "README.rst"
 requires-python = ">=3.7"
-license = { text = "MIT" }
+license = "MIT"
 keywords = [
   "bit field",
   "bit parsing",
@@ -22,7 +22,6 @@ authors = [
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Fixes the following two warnings that happen as part of the build:

1.
```text
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!
          ********************************************************************************
          Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
          By 2026-Feb-18, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
  !!
```

2.
```text
SetuptoolsDeprecationWarning: License classifiers are deprecated.
  !!
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:
          License :: OSI Approved :: MIT License
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
  !!
```
