### PR TITLE
Build wheels for more architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            use_qemu: true
-            architectures: auto ppc64le
           - os: ubuntu-24.04-arm
             architectures: auto armv7l
           - os: macos-13 # Intel
@@ -26,12 +24,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - if: matrix.use_qemu
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            use_qemu: true
+            architectures: auto ppc64le
+          - os: ubuntu-24.04-arm
+            architectures: auto armv7l
+          - os: macos-13 # Intel
+          - os: macos-14 # Apple Silicon
+          - os: windows-latest
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
+
+      - if: matrix.use_qemu
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v4
@@ -29,6 +43,8 @@ jobs:
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS: ${{ matrix.architectures || 'auto' }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = """This module performs conversions between Python values \
 and C bit field structs represented as Python \
 byte strings."""
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = [
   "bit field",


### PR DESCRIPTION
This PR adds more architectures with pre-built wheels. Most importantly, this adds linux-aarch64 and linux-armv7l, which are fairly common platforms.
You can see a test run here: <https://github.com/inomotech-foss/bitstruct/actions/runs/14686144725>


FYI: On s390x the tests fail: <https://github.com/inomotech-foss/bitstruct/actions/runs/14686026768/job/41214698872>. I don't think it's a particularly relevant architecture, I just happened to notice it while working on this.