### PR TITLE
Fix float16 pack/unpack on big-endian architectures

### DIFF
--- a/src/bitstruct/c.c
+++ b/src/bitstruct/c.c
@@ -430,11 +430,11 @@ static void pack_float_16(struct bitstream_writer_t *self_p,
 #if PY_VERSION_HEX >= 0x030B00A7
     PyFloat_Pack2(PyFloat_AsDouble(value_p),
                   (char*)&buf[0],
-                  PY_BIG_ENDIAN);
+                  0);
 #else
     _PyFloat_Pack2(PyFloat_AsDouble(value_p),
                    &buf[0],
-                   PY_BIG_ENDIAN);
+                   0);
 #endif
     bitstream_writer_write_bytes(self_p, &buf[0], sizeof(buf));
 }
@@ -447,9 +447,9 @@ static PyObject *unpack_float_16(struct bitstream_reader_t *self_p,
 
     bitstream_reader_read_bytes(self_p, &buf[0], sizeof(buf));
 #if PY_VERSION_HEX >= 0x030B00A7
-    value = PyFloat_Unpack2((const char*)&buf[0], PY_BIG_ENDIAN);
+    value = PyFloat_Unpack2((const char*)&buf[0], 0);
 #else
-    value = _PyFloat_Unpack2(&buf[0], PY_BIG_ENDIAN);
+    value = _PyFloat_Unpack2(&buf[0], 0);
 #endif
 
     return (PyFloat_FromDouble(value));


### PR DESCRIPTION
`pack_float_16()` and `unpack_float_16()` pass `PY_BIG_ENDIAN` as the byte-order parameter to `PyFloat_Pack2`/`PyFloat_Unpack2` (and their underscore-prefixed predecessors).

That parameter is named `le` (little-endian): 0 means big-endian storage, 1 means little-endian. `PY_BIG_ENDIAN` expands to 1 on big-endian hosts, which tells the API to use little-endian storage — the opposite of what the bitstream layer expects (MSB-first).

On little-endian hosts `PY_BIG_ENDIAN` is 0, which accidentally matches the bitstream convention, so the bug is invisible there.

Fix: always pass 0 (big-endian) so the buffer matches the bitstream byte order regardless of host architecture.

This fixes the big-endian test failures reported in #21 (second comment, by @besser82):

```
FAIL: test_pack — b'\x00<' != b'<\x00'
FAIL: test_unpack — (3.5762786865234375e-06,) != (1.0,)
```

Note: the first comment in #21 (byte-order suffixes `<`/`>` being silently ignored by the C extension) is a separate issue and is not addressed here.